### PR TITLE
add freetype and ttf-freefont to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repos
     chromium@edge \
     harfbuzz@edge \
     nss@edge \
+    freetype@edge \
+    ttf-freefont@edge \
     && rm -rf /var/cache/* \
     && mkdir /var/cache/apk
 


### PR DESCRIPTION
without these packages, launching chromium fails

see https://git.io/fjGLB and https://git.io/fjGL0