### PR TITLE
add branch with-puppeteer-cn to support for Chinese,Janpanse and Korean language site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - `with-node` [(Dockerfile)](https://github.com/Zenika/alpine-chrome/blob/master/with-node/Dockerfile)
 - `with-puppeteer` [(Dockerfile)](https://github.com/Zenika/alpine-chrome/blob/master/with-puppeteer/Dockerfile)
 - `72`
+- `with-puppeteer-cn` [(Dockerfile)](https://github.com/huhai463127310/alpine-chrome/blob/with-puppeteer-cn/with-puppeteer-cn/Dockerfile)
 
 # alpine-chrome
 
@@ -100,6 +101,12 @@ If you have a NodeJS/Puppeteer script in your `src` folder named `pdf.js`, you c
 
 ```
 docker run -it --rm -v $(pwd)/src:/usr/src/app/src --cap-add=SYS_ADMIN zenika/alpine-chrome:with-puppeteer node src/pdf.js
+```
+You can use with-puppeteer-cn tag for Chinese,Janpanse and Korean language support.
+
+The following command will take a screenshot for m.baidu.com (the most popular search engine in China), and save the image to `./screentshot.png`.
+```
+docker run -it --rm  -v $(pwd):/home/chrome --cap-add=SYS_ADMIN zenika/alpine-chrome:with-puppeteer-cn node src/screenshot.js
 ```
 
 # References

--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ If you have a NodeJS/Puppeteer script in your `src` folder named `pdf.js`, you c
 ```
 docker run -it --rm -v $(pwd)/src:/usr/src/app/src --cap-add=SYS_ADMIN zenika/alpine-chrome:with-puppeteer node src/pdf.js
 ```
-You can use with-puppeteer-cn tag for Chinese,Janpanse and Korean language support.
+You can use [huhai463127310/alpine-chrome:with-puppeteer-cn](https://hub.docker.com/r/huhai463127310/alpine-chrome) for Chinese,Janpanse and Korean language support.
 
 The following command will take a screenshot for m.baidu.com (the most popular search engine in China), and save the image to `./screentshot.png`.
 ```
-docker run -it --rm  -v $(pwd):/home/chrome --cap-add=SYS_ADMIN zenika/alpine-chrome:with-puppeteer-cn node src/screenshot.js
+docker run -it --rm  -v $(pwd):/home/chrome --cap-add=SYS_ADMIN huhai463127310/alpine-chrome:with-puppeteer-cn node src/screenshot.js
 ```
 
 # References

--- a/with-puppeteer-cn/Dockerfile
+++ b/with-puppeteer-cn/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add ttf-dejavu
 # copy font files
 COPY font/* /usr/share/fonts/
 USER chrome
-
+COPY --chown=chrome src/* ./src/
+RUN mkdir -p /home/chrome/
 ENTRYPOINT ["tini", "--"]
-CMD ["node", "src/pdf"]
+CMD ["node", "src/screenshot"]

--- a/with-puppeteer-cn/Dockerfile
+++ b/with-puppeteer-cn/Dockerfile
@@ -1,0 +1,11 @@
+FROM zenika/alpine-chrome:with-puppeteer
+
+USER root
+# add font manager
+RUN apk add ttf-dejavu
+# copy font files
+COPY font/* /usr/share/fonts/
+USER chrome
+
+ENTRYPOINT ["tini", "--"]
+CMD ["node", "src/pdf"]

--- a/with-puppeteer-cn/src/package.json
+++ b/with-puppeteer-cn/src/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "screenshot",
+  "version": "1.0.0",
+  "description": "take a screen shot after page loading done and save to screenshot.png",
+  "main": "screenshot.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/huhai463127310/alpine-chrome.git"
+  },
+  "author": "huhai463127310",
+  "license": "MIT"
+}

--- a/with-puppeteer-cn/src/screenshot.js
+++ b/with-puppeteer-cn/src/screenshot.js
@@ -1,0 +1,23 @@
+const puppeteer = require('puppeteer');
+
+function timeout(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+};
+
+(async() => {
+    const browser = await puppeteer.launch({
+        bindAddress: "0.0.0.0",
+        args: [
+          "--headless",
+          "--disable-gpu",
+          "--disable-dev-shm-usage",
+          "--remote-debugging-port=9222",
+          "--remote-debugging-address=0.0.0.0"
+        ]
+    });
+    const page = await browser.newPage();
+    await page.setViewport({width: 412, height: 732})
+    await page.goto('http://m.baidu.com', {waitUntil: 'networkidle2'});
+    await page.screenshot({path: '/home/chrome/screenshot.png'});
+    await browser.close();
+})();


### PR DESCRIPTION
You can use [huhai463127310/alpine-chrome:with-puppeteer-cn](https://hub.docker.com/r/huhai463127310/alpine-chrome) for Chinese,Janpanse and Korean language support.

The following command will take a screenshot for m.baidu.com (the most popular search engine in China), and save the image to `./screentshot.png`.