### PR TITLE
add `with-chromedriver` and `with-selenoid`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,20 +4,20 @@ ARG BUILD_DATE
 ARG VCS_REF
 
 LABEL org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.description="Chrome running in headless mode in a tiny Alpine image" \
-      org.label-schema.name="alpine-chrome" \
-      org.label-schema.schema-version="1.0.0-rc1" \
-      org.label-schema.usage="https://github.com/Zenika/alpine-chrome/blob/master/README.md" \
-      org.label-schema.vcs-url="https://github.com/Zenika/alpine-chrome" \
-      org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vendor="Zenika" \
-      org.label-schema.version="latest"
+    org.label-schema.description="Chrome running in headless mode in a tiny Alpine image" \
+    org.label-schema.name="alpine-chrome" \
+    org.label-schema.schema-version="1.0.0-rc1" \
+    org.label-schema.usage="https://github.com/Zenika/alpine-chrome/blob/master/README.md" \
+    org.label-schema.vcs-url="https://github.com/Zenika/alpine-chrome" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vendor="Zenika" \
+    org.label-schema.version="latest"
 
 # Installs latest Chromium package.
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories \
     && echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
     && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
-    && echo "http://dl-cdn.alpinelinux.org/alpine/v3.11/main" >> /etc/apk/repositories \
+    && echo "http://dl-cdn.alpinelinux.org/alpine/v3.12/main" >> /etc/apk/repositories \
     && apk upgrade -U -a \
     && apk add --no-cache \
     libstdc++ \

--- a/with-chromedriver/Dockerfile
+++ b/with-chromedriver/Dockerfile
@@ -1,0 +1,10 @@
+FROM zenika/alpine-chrome
+
+USER root
+RUN apk add --no-cache chromium-chromedriver \
+    && rm -rf /var/lib/apt/lists/* \
+    /var/cache/apk/* \
+    /usr/share/man \
+    /tmp/*
+USER chrome
+ENTRYPOINT ["chromedriver","--whitelisted-ips"]

--- a/with-chromedriver/hooks/post_push
+++ b/with-chromedriver/hooks/post_push
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+CURRENT_VERSION_CHROMIUM=`docker container run --rm --entrypoint "" zenika/alpine-chrome:with-chromedriver chromium-browser --version`
+echo ${CURRENT_VERSION_CHROMIUM:9:2}
+CURRENT_CHROMEDRIVER_VERSION=`docker container run --rm --entrypoint "" zenika/alpine-chrome:with-chromedriver chromedriver -v`
+echo ${CURRENT_CHROMEDRIVER_VERSION:13:2}
+
+for tag in ${CURRENT_VERSION_CHROMIUM:9:2}; do
+    echo $tag        
+    tagStart=$(expr index "$IMAGE_NAME" :)
+    repoName=${IMAGE_NAME:0:tagStart-1}
+    docker tag $IMAGE_NAME ${repoName}:${tag}-with-chromedriver 
+    docker push ${repoName}:${tag}-with-chromedriver 
+    docker tag $IMAGE_NAME ${repoName}:${tag}-with-chromedriver -${CURRENT_CHROMEDRIVER_VERSION:13:2}
+    docker push ${repoName}:${tag}-with-chromedriver -${CURRENT_CHROMEDRIVER_VERSION:13:2}
+done

--- a/with-chromedriver/hooks/post_push
+++ b/with-chromedriver/hooks/post_push
@@ -12,6 +12,6 @@ for tag in ${CURRENT_VERSION_CHROMIUM:9:2}; do
     repoName=${IMAGE_NAME:0:tagStart-1}
     docker tag $IMAGE_NAME ${repoName}:${tag}-with-chromedriver 
     docker push ${repoName}:${tag}-with-chromedriver 
-    docker tag $IMAGE_NAME ${repoName}:${tag}-with-chromedriver -${CURRENT_CHROMEDRIVER_VERSION:13:2}
-    docker push ${repoName}:${tag}-with-chromedriver -${CURRENT_CHROMEDRIVER_VERSION:13:2}
+    docker tag $IMAGE_NAME ${repoName}:${tag}-with-chromedriver-${CURRENT_CHROMEDRIVER_VERSION:13:2}
+    docker push ${repoName}:${tag}-with-chromedriver-${CURRENT_CHROMEDRIVER_VERSION:13:2}
 done

--- a/with-selenoid/Dockerfile
+++ b/with-selenoid/Dockerfile
@@ -1,0 +1,17 @@
+FROM aerokube/selenoid:latest-release as selenoid
+FROM zenika/alpine-chrome:with-chromedriver
+
+USER root
+RUN apk add --no-cache ca-certificates tzdata mailcap \
+    && rm -rf /var/lib/apt/lists/* \
+    /var/cache/apk/* \
+    /usr/share/man \
+    /tmp/*
+
+COPY --from=selenoid /usr/bin/selenoid /usr/bin/selenoid
+ADD browsers.json /etc/selenoid/browsers.json
+
+USER chrome
+EXPOSE 4444
+
+ENTRYPOINT ["/usr/bin/selenoid", "-listen", ":4444", "-conf", "/etc/selenoid/browsers.json"]

--- a/with-selenoid/browsers.json
+++ b/with-selenoid/browsers.json
@@ -1,0 +1,13 @@
+{
+    "chrome": {
+        "default": "latest",
+        "versions": {
+            "latest": {
+                "image": [
+                    "chromedriver",
+                    "--whitelisted-ips"
+                ]
+            }
+        }
+    }
+}

--- a/with-selenoid/hooks/post_push
+++ b/with-selenoid/hooks/post_push
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+CURRENT_VERSION_CHROMIUM=`docker container run --rm --entrypoint "" zenika/alpine-chrome:with-selenoid chromium-browser --version`
+echo ${CURRENT_VERSION_CHROMIUM:9:2}
+CURRENT_SELENOID_VERSION=`docker container run --rm --entrypoint "" zenika/alpine-chrome:with-selenoid selenoid -version`
+echo ${CURRENT_SELENOID_VERSION:14:4}
+
+for tag in ${CURRENT_VERSION_CHROMIUM:9:2}; do
+    echo $tag        
+    tagStart=$(expr index "$IMAGE_NAME" :)
+    repoName=${IMAGE_NAME:0:tagStart-1}
+    docker tag $IMAGE_NAME ${repoName}:${tag}-with-selenoid 
+    docker push ${repoName}:${tag}-with-selenoid 
+    docker tag $IMAGE_NAME ${repoName}:${tag}-with-selenoid -${CURRENT_SELENOID_VERSION:14:4}
+    docker push ${repoName}:${tag}-with-selenoid -${CURRENT_SELENOID_VERSION:14:4}
+done

--- a/with-selenoid/hooks/post_push
+++ b/with-selenoid/hooks/post_push
@@ -12,6 +12,6 @@ for tag in ${CURRENT_VERSION_CHROMIUM:9:2}; do
     repoName=${IMAGE_NAME:0:tagStart-1}
     docker tag $IMAGE_NAME ${repoName}:${tag}-with-selenoid 
     docker push ${repoName}:${tag}-with-selenoid 
-    docker tag $IMAGE_NAME ${repoName}:${tag}-with-selenoid -${CURRENT_SELENOID_VERSION:14:4}
-    docker push ${repoName}:${tag}-with-selenoid -${CURRENT_SELENOID_VERSION:14:4}
+    docker tag $IMAGE_NAME ${repoName}:${tag}-with-selenoid-${CURRENT_SELENOID_VERSION:14:4}
+    docker push ${repoName}:${tag}-with-selenoid-${CURRENT_SELENOID_VERSION:14:4}
 done


### PR DESCRIPTION
Hey!
I faced the same issue as in #48.
Edge repository of Alpine package has chromedriver 84 now which is incompatible with chromium 83 and `apk` wouldn't let me install chromedriver 83.

So I decided to do what you suggested in the #48 and add `with-chromedriver` tag.

But my use-case is a bit deeper, I'm using the https://github.com/aerokube/selenoid (you can find more details here https://github.com/aerokube/selenoid/issues/966), so I decided this might be useful for someone else and added the `with-selenoid` tag as well.

Let me know what do you think!