### PR TITLE
Improve apk cache control in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositorie
     && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
     && echo "http://dl-cdn.alpinelinux.org/alpine/v3.11/main" >> /etc/apk/repositories \
     && apk upgrade -U -a \
-    && apk add --no-cache \
+    && apk add \
     libstdc++ \
     chromium \
     harfbuzz \


### PR DESCRIPTION
`apk add` shouldn't ignore the local cache and fetch remote package info,
because previous command `apk upgrade` was called with the parameter `-U`,
which will update and save the updated apk cache, which can be used.