### PR TITLE
Remove unnecessary clean up commands in Dockerfile

### DIFF
--- a/with-chromedriver/Dockerfile
+++ b/with-chromedriver/Dockerfile
@@ -1,10 +1,6 @@
 FROM zenika/alpine-chrome
 
 USER root
-RUN apk add --no-cache chromium-chromedriver \
-    && rm -rf /var/lib/apt/lists/* \
-    /var/cache/apk/* \
-    /usr/share/man \
-    /tmp/*
+RUN apk add --no-cache chromium-chromedriver
 USER chrome
 ENTRYPOINT ["chromedriver","--whitelisted-ips"]

--- a/with-selenoid/Dockerfile
+++ b/with-selenoid/Dockerfile
@@ -2,11 +2,7 @@ FROM aerokube/selenoid:latest-release as selenoid
 FROM zenika/alpine-chrome:with-chromedriver
 
 USER root
-RUN apk add --no-cache ca-certificates tzdata mailcap \
-    && rm -rf /var/lib/apt/lists/* \
-    /var/cache/apk/* \
-    /usr/share/man \
-    /tmp/*
+RUN apk add --no-cache ca-certificates tzdata mailcap
 
 COPY --from=selenoid /usr/bin/selenoid /usr/bin/selenoid
 ADD browsers.json /etc/selenoid/browsers.json


### PR DESCRIPTION
`with-chromedriver/Dockerfile` `with-selenoid/Dockerfile` were added in #111 after #124, the unnecessary clean up commands need to be removed again 😅 