### PR TITLE
Replace ADD with COPY for file in with-selenoid/Dockerfile

### DIFF
--- a/with-selenoid/Dockerfile
+++ b/with-selenoid/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache ca-certificates tzdata mailcap \
     /tmp/*
 
 COPY --from=selenoid /usr/bin/selenoid /usr/bin/selenoid
-ADD browsers.json /etc/selenoid/browsers.json
+COPY browsers.json /etc/selenoid/browsers.json
 
 USER chrome
 EXPOSE 4444


### PR DESCRIPTION
Dockerfile best practices reference:
- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy

> For other items (files, directories) that do not require ADD’s tar
> auto-extraction capability, you should always use COPY.