### PR TITLE
Add example for alpine-chrome deployment on k8s

### DIFF
--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -15,7 +15,7 @@ kubectl apply -f deployment.yml
 You can port forward from your cluster to your local machine with following command
 
 ```
- kubectl port-forward deployment/alpine-chrome-deployment 9222
+kubectl port-forward deployment/alpine-chrome-deployment 9222
 ```
 
 Then go to `localhost:9222` with your browser (must be a chrome base browser!)

--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -1,0 +1,26 @@
+# zenika/alpine-chrome in k8s
+
+Here is an example with kubernetes on how to launch and use `zenika/alpine-chrome`.
+
+## Launch
+
+Inside this folder, run the following command:
+
+```
+kubectl apply -f deployment.yml
+```
+
+## Test
+
+You can port forward from your cluster to your local machine with following command
+
+```
+ kubectl port-forward deployment/alpine-chrome-deployment 9222
+```
+
+Then go to `localhost:9222` with your browser (must be a chrome base browser!)
+You can enter `https://google.com` or any service you want to call.
+
+## Configuration
+
+You may change the `zenika/alpine-chrome` image you want to use modifying the line 23 in `deployment.yml`.

--- a/examples/k8s/deployment.yml
+++ b/examples/k8s/deployment.yml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alpine-chrome-deployment
+  labels:
+    app: alpine-chrome
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: alpine-chrome
+  template:
+    metadata:
+      labels:
+        name: alpine-chrome
+    spec:
+      containers:
+      - args:
+        - --remote-debugging-address=0.0.0.0
+        - --remote-debugging-port=9222
+        - --headless
+        - --disable-gpu
+        image: zenika/alpine-chrome
+        livenessProbe:
+          httpGet:
+            path: /json
+            port: 9222
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        name: zenika-alpine-chrome
+        readinessProbe:
+          httpGet:
+            path: /json
+            port: 9222
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2Gi
+          requests:
+            cpu: "1"
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - SYS_ADMIN
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /home/chrome
+          name: chrome
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      volumes:
+      - emptyDir: {}
+        name: tmp
+      - emptyDir: {}
+        name: chrome
+status: {}


### PR DESCRIPTION
Closes https://github.com/Zenika/alpine-chrome/issues/109 by adding an example on how to successfully run alpine-chrome on k8s