### PR TITLE
reduce nodejs image size

### DIFF
--- a/with-node/Dockerfile
+++ b/with-node/Dockerfile
@@ -1,6 +1,6 @@
 FROM zenika/alpine-chrome
 
 USER root
-RUN apk add --no-cache tini make gcc g++ python3 git nodejs nodejs-npm yarn
+RUN apk add --no-cache tini python3 git nodejs-npm yarn
 USER chrome
 ENTRYPOINT ["tini", "--"]


### PR DESCRIPTION
Hello,

I noted `nodejs` package doesn't add `npm` binary:

```sh
/usr/src/app # apk add nodejs
fetch http://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
(1/2) Installing c-ares (1.17.1-r1)
(2/2) Installing nodejs (14.16.1-r2)
Executing busybox-1.33.0-r4.trigger
OK: 494 MiB in 154 packages
/usr/src/app # node --version
v14.16.1
/usr/src/app # npm --version
/bin/sh: npm: not found
```

However, using `nodejs-npm` adds both binaries:

```sh
/usr/src/app # apk del nodejs
(1/2) Purging nodejs (14.16.1-r2)
(2/2) Purging c-ares (1.17.1-r1)
Executing busybox-1.33.0-r4.trigger
OK: 460 MiB in 152 packages
/usr/src/app # apk add nodejs-npm
(1/3) Installing c-ares (1.17.1-r1)
(2/3) Installing nodejs (14.16.1-r2)
(3/3) Installing npm (12.22.1-r0)
Executing busybox-1.33.0-r4.trigger
OK: 521 MiB in 155 packages
/usr/src/app # node --version
v14.16.1
/usr/src/app # npm --version
6.14.12
```

so I guess `nodejs` is a not necessary package at all?