### PR TITLE
New Puppeteer image with Xvfb included to test ChromeExtension 

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,7 @@ Assuming you have a NodeJS/Puppeteer script in your `src` folder named `extensio
 docker container run -it --rm -v $(pwd)/src:/usr/src/app/src --cap-add=SYS_ADMIN zenika/alpine-chrome:with-puppeteer-xvfb node src/extension.js
 ```
 
-The extension provided
-
+The extension provided will change the page background in red for every website visited. This demo will load the extension and take a screenshot of the icanhazip.com website.
 
 # How to use with Playwright
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,20 @@ These websites are tested with the following supported languages:
 - Japanese (with `https://www.yahoo.co.jp/`)
 - Korean (with `https://www.naver.com/`)
 
+# How to use with Puppeteer to test a Chrome Extension
+[According to puppeteer official doc](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#working-with-chrome-extensions) you can not test a Chrome Extension in headleass mode. You need a display available, that's where Xvfb comes in.
+
+See the ["with-puppeteer-xvfb"](https://github.com/Zenika/alpine-chrome/blob/master/with-puppeteer-xvfb) folder for more details. We have to [follow the mapping of Chromium => Puppeteer described here](https://github.com/puppeteer/puppeteer/blob/main/versions.js).
+
+Assuming you have a NodeJS/Puppeteer script in your `src` folder named `extension.js`, and the unpacked extension in the `chrome-extension` folder, you can launch it using the following command:
+
+```
+docker container run -it --rm -v $(pwd)/src:/usr/src/app/src --cap-add=SYS_ADMIN zenika/alpine-chrome:with-puppeteer-xvfb node src/extension.js
+```
+
+The extension provided
+
+
 # How to use with Playwright
 
 Like ["Puppeteer"](https://pptr.dev/#?product=Puppeteer&version=v6.0.0&show=api-class-browser), we can do a lot things using ["Playwright"](https://playwright.dev/docs/core-concepts/#browser) with our Chrome Headless.

--- a/with-puppeteer-xvfb/Dockerfile
+++ b/with-puppeteer-xvfb/Dockerfile
@@ -9,6 +9,6 @@ USER chrome
 
 ENV DISPLAY :99
 
-COPY docker-entrypoint.sh ./
+COPY --chown=chrome . ./
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"] 
 CMD ["node", "src/extension.js"]

--- a/with-puppeteer-xvfb/Dockerfile
+++ b/with-puppeteer-xvfb/Dockerfile
@@ -1,0 +1,14 @@
+FROM zenika/alpine-chrome:with-puppeteer
+
+USER 0
+RUN apk upgrade -U -a \
+    && apk add xvfb\
+    && rm -rf /var/cache/* \
+    && mkdir /var/cache/apk
+USER chrome
+
+ENV DISPLAY :99
+
+COPY docker-entrypoint.sh ./
+ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"] 
+CMD ["node", "src/extension.js"]

--- a/with-puppeteer-xvfb/Dockerfile
+++ b/with-puppeteer-xvfb/Dockerfile
@@ -10,5 +10,6 @@ USER chrome
 ENV DISPLAY :99
 
 COPY --chown=chrome . ./
+RUN chmod +x docker-entrypoint.sh
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"] 
 CMD ["node", "src/extension.js"]

--- a/with-puppeteer-xvfb/docker-entrypoint.sh
+++ b/with-puppeteer-xvfb/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+XVFB_WHD=${XVFB_WHD:-1280x720x16}
+
+echo "Starting Xvfb"
+Xvfb :99 -ac -screen 0 $XVFB_WHD -nolisten tcp &
+sleep 2
+
+echo "Executing command $@"
+export DISPLAY=:99
+
+exec "$@"

--- a/with-puppeteer-xvfb/hooks/post_push
+++ b/with-puppeteer-xvfb/hooks/post_push
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-CURRENT_VERSION_CHROMIUM=`docker container run --rm --entrypoint "" zenika/alpine-chrome:with-puppeteer-xvfb chromium-browser --version`
+CURRENT_VERSION_CHROMIUM=`docker container run --rm --entrypoint "" chriscamicas/alpine-chrome:with-puppeteer-xvfb chromium-browser --version`
 echo ${CURRENT_VERSION_CHROMIUM:9:2}
 
 for tag in ${CURRENT_VERSION_CHROMIUM:9:2}; do

--- a/with-puppeteer-xvfb/hooks/post_push
+++ b/with-puppeteer-xvfb/hooks/post_push
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-CURRENT_VERSION_CHROMIUM=`docker container run --rm --entrypoint "" chriscamicas/alpine-chrome:with-puppeteer-xvfb chromium-browser --version`
+CURRENT_VERSION_CHROMIUM=`docker container run --rm --entrypoint "" zenika/alpine-chrome:with-puppeteer-xvfb chromium-browser --version`
 echo ${CURRENT_VERSION_CHROMIUM:9:2}
 
 for tag in ${CURRENT_VERSION_CHROMIUM:9:2}; do

--- a/with-puppeteer-xvfb/hooks/post_push
+++ b/with-puppeteer-xvfb/hooks/post_push
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+CURRENT_VERSION_CHROMIUM=`docker container run --rm --entrypoint "" zenika/alpine-chrome:with-puppeteer-xvfb chromium-browser --version`
+echo ${CURRENT_VERSION_CHROMIUM:9:2}
+
+for tag in ${CURRENT_VERSION_CHROMIUM:9:2}; do
+    echo $tag        
+    tagStart=$(expr index "$IMAGE_NAME" :)
+    repoName=${IMAGE_NAME:0:tagStart-1}
+    docker tag $IMAGE_NAME ${repoName}:${tag}-with-puppeteer-xvfb
+    docker push ${repoName}:${tag}-with-puppeteer-xvfb
+done

--- a/with-puppeteer-xvfb/src/chrome-extension/content-script.js
+++ b/with-puppeteer-xvfb/src/chrome-extension/content-script.js
@@ -1,0 +1,3 @@
+window.addEventListener('DOMContentLoaded', (event) => {
+    document.body.style.backgroundColor = 'red';
+});

--- a/with-puppeteer-xvfb/src/chrome-extension/manifest.json
+++ b/with-puppeteer-xvfb/src/chrome-extension/manifest.json
@@ -1,0 +1,18 @@
+{
+    "name": "Chrome Sample Extension",
+    "version": "1.0.0",
+    "description": "Sample Extension to turn the background in red",
+    "manifest_version": 2,
+    "content_scripts": [
+        {
+            "matches": [
+                "http://*/*",
+                "https://*/*"
+            ],
+            "run_at": "document_start",
+            "js": [
+                "content-script.js"
+            ]
+        }
+    ]
+}

--- a/with-puppeteer-xvfb/src/extension.js
+++ b/with-puppeteer-xvfb/src/extension.js
@@ -1,0 +1,25 @@
+const puppeteer = require("puppeteer");
+const path = require("path");
+
+(async () => {
+  let extensionPath = path.join(__dirname, "chrome-extension");
+  
+  const browser = await puppeteer.launch({
+    bindAddress: "0.0.0.0",
+    headless: false,
+    ignoreDefaultArgs: ["--disable-extensions"],
+    args: [
+      `--load-extension=${extensionPath}`,
+      "--disable-gpu",
+      "--disable-dev-shm-usage",
+      "--remote-debugging-port=9222",
+      "--remote-debugging-address=0.0.0.0"
+    ]
+  });
+  const page = await browser.newPage();
+  await page.goto("http://icanhazip.com/", {
+    waitUntil: "networkidle2"
+  });
+  await page.screenshot({ path: "src/screenshot.png" });
+  await browser.close();
+})();


### PR DESCRIPTION
This PR adds a new Puppeteer docker image based on the existing one, with the addition of Xfvb.
This image is usefull to test Chrome/Chromium Extension, and it comes with a demo-extension included.
Xfvb is needed to run Chrome Headfull, since the headless mode prevent extension from loading/running.

Closes #167 