### PR TITLE
Added platform arg to docker build

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-docker image build --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` -t $IMAGE_NAME .
+docker image build --build-arg VCS_REF=`git rev-parse --short HEAD` --platform linux/arm64,linux/amd64 --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` -t $IMAGE_NAME .


### PR DESCRIPTION
Hi @jlandure, thanks a lot for your work!

Here's my PR to open discussion for publishing multi-arch images:

https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/ has a quick guide on what I propose. The `docker buildx way`. I have been testing this out and using this extensively to publish multi-arch image to multiple registries. 

Suggestion - what about using GitHub Actions to publish multi-arch multi-registry images? Here's my repo which implements it this way - https://github.com/drpayyne/docker-php. There's a single workflow file for each package and I build for both `linux/arm64` and `linux/amd64` and publish it to both DockerHub and GitHub Packages. 

This is a draft PR which I intend to take forward in your preferred way of action. Please let me know how we can do this. From a quick overview, only the Deno Dockerfile needs a little modification to get it to work multi-platform. We need to pick the appropriate Deno download URL based on the target architecture. A preview of how it would be is implemented by me for another repo at https://github.com/markshust/docker-magento/pull/516/files

