### PR TITLE
Fix options required to connect remotely

### DIFF
--- a/with-chromedriver/Dockerfile
+++ b/with-chromedriver/Dockerfile
@@ -3,4 +3,4 @@ FROM zenika/alpine-chrome
 USER root
 RUN apk add --no-cache chromium-chromedriver
 USER chrome
-ENTRYPOINT ["chromedriver","--whitelisted-ips"]
+ENTRYPOINT ["chromedriver","--allowed-ips=","--allowed-origins=*"]


### PR DESCRIPTION
As noted in https://bugs.chromium.org/p/chromedriver/issues/detail?id=3857#c26 the correct options are --whitelisted-ips= --allowed-origins=*

Fixes #197 