### PR TITLE
Avoid entrypoint flags duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Launch the container using:
 
 ## Default entrypoint
 
-The default entrypoint does the following command: `chromium-browser --headless --disable-gpu --disable-software-rasterizer --disable-dev-shm-usage`
+The default entrypoint runs `chromium-browser` in headles mode with some common flags(see [Dockerfile](./Dockerfile) for exact flags).
 
 You can get full control by overriding the entrypoint using: `docker container run -it --rm --entrypoint "" zenika/alpine-chrome chromium-browser ...`
 


### PR DESCRIPTION
Duplication is always bad as someone needs to keep the lists up to date. Otherwise we have what we have - README.md states lies to project users.