### PR TITLE
Automatically build new images once a week

### DIFF
--- a/.github/workflows/build-one.yml
+++ b/.github/workflows/build-one.yml
@@ -121,14 +121,14 @@ jobs:
           echo "value=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Login to DockerHub
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to US GAR
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/login-action@v2
         with:
           registry: us-docker.pkg.dev
@@ -136,7 +136,7 @@ jobs:
           password: ${{ secrets.GAR_JSON_KEY }}
 
       - name: Login to Europe GAR
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/login-action@v2
         with:
           registry: europe-docker.pkg.dev
@@ -144,7 +144,7 @@ jobs:
           password: ${{ secrets.GAR_JSON_KEY }}
 
       - name: Login to Asia GAR
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/login-action@v2
         with:
           registry: asia-docker.pkg.dev
@@ -152,13 +152,13 @@ jobs:
           password: ${{ secrets.GAR_JSON_KEY }}
 
       - name: Set up Docker Buildx with docker-container driver
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/setup-buildx-action@v2
         with:
           driver: docker-container
 
       - name: Build and push
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         env:
           IMAGE_NAME: ${{ env.IMAGE_REPOSITORY }}:${{ inputs.tag }}
           IMAGE_VERSIONED_NAME: ${{ env.IMAGE_REPOSITORY }}:${{ steps.tag.outputs.value }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    - cron: '25 4 * * 4'
+  workflow_dispatch:
 
 jobs:
   build-base:


### PR DESCRIPTION
The generation of new images currently depends on changes being pushed to the master branch, causing many chromium versions to not be available as image variants during periods of no activity.

This PR adds a scheduled trigger to the already existing build workflow, causing new images to be generated once a week. I furthermore included a _workflow_dispatch_ trigger, allowing maintainers to trigger a new build from the github action console, without code modifications, if desired.

The removal of the `github.event_name == 'push'` check in the workflow doesn't change the existing behavior, as the ref for pull request events has the format `refs/pull/:prNumber/merge`
