### PR TITLE
[chromedriver] EXPOSE port 9515

### DIFF
--- a/with-chromedriver/Dockerfile
+++ b/with-chromedriver/Dockerfile
@@ -3,4 +3,5 @@ FROM zenika/alpine-chrome
 USER root
 RUN apk add --no-cache chromium-chromedriver
 USER chrome
+EXPOSE 9515
 ENTRYPOINT ["chromedriver","--allowed-ips=","--allowed-origins=*"]


### PR DESCRIPTION
* EXPOSE the default 9515 port for remote webdriver

For Gitlab CI, it's great to have alphine-chrome for a service to run with remote support, but it could not expose the default port of 9515